### PR TITLE
Functionality Added To Check Active Date Window

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -583,3 +583,4 @@ FodyWeavers.xsd
 # Additional files built by Visual Studio
 
 # End of https://www.toptal.com/developers/gitignore/api/csharp,visualstudio
+FileSystemWatcher.config

--- a/PollFilePath.cs
+++ b/PollFilePath.cs
@@ -31,6 +31,15 @@ namespace FileWatcher
 
             foreach (var job in batchJobs)
             {
+                //Check and Validate that today is a valid batch window day
+                string[] windowDays = job.Element("WindowDays").Value.Split('|');
+                string abbreviatedDay = DateTime.Now.DayOfWeek.ToString().Substring(0, 3);
+                if (!windowDays.Contains(abbreviatedDay)){
+                    Console.WriteLine($"today is not active day for Job ID {job.Element("JobID")}");
+                    continue;
+                }
+
+                //Check and validate that Batch window is open
                 TimeOnly startTime = TimeOnly.Parse(job.Element("WindowStart").Value);
                 TimeOnly endTime = TimeOnly.Parse(job.Element("WindowEnd").Value);
                 TimeOnly currentTime = TimeOnly.Parse(DateTime.Now.ToLongTimeString());

--- a/WatcherJob.cs
+++ b/WatcherJob.cs
@@ -37,6 +37,8 @@ namespace FileWatcher
             while (retryCount < 3) { 
                 try { 
                     File.Move(fileInfo.FullName, ($"{outputPath}{fileInfo.Name.Split(".")[0]}_{formattedTime}{fileInfo.Extension}"));
+                    Console.WriteLine("File Moved.");
+                    Console.WriteLine($"{outputPath}{fileInfo.Name.Split(".")[0]}_{formattedTime}{fileInfo.Extension}");
                 }
                 catch (IOException error) { 
                     retryCount++;


### PR DESCRIPTION
Added functionality that will check if today's abbreviated date is included in the BatchJob's Window Days

Tested by: 

1. checking base functionality with all open days and confirm still works and will move file
2. Removed date from config and confirmed that output message was correctly output.
3. Put back today's abbreviated day into the config and confirm that functionality works again.