### PR TITLE
Disposed of FileWatchers at the end of the inactive window.

### DIFF
--- a/WatcherJob.cs
+++ b/WatcherJob.cs
@@ -9,7 +9,7 @@ namespace FileWatcher
 {
     public class WatcherJob : FileSystemWatcher
     {
-        public WatcherJob(string jobType,  string monitoredPath, string? outputFilePath, string filenamePattern = "*.*") {
+        public WatcherJob(string jobType,  string monitoredPath, string? outputFilePath, string? filenamePattern) {
 
             switch (jobType)
             {


### PR DESCRIPTION
- Tested and confirmed multiple batch jobs work simultaneously
- switched List to dictionary where key is the JobID. This simplifies checking which jobs are active and allows for easier single disposal.